### PR TITLE
Update revoke.pp to work with easyrsa 3

### DIFF
--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -64,5 +64,13 @@ define openvpn::revoke (
     cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
     creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
     provider => 'shell',
+    notify   => Exec["update crl.pem on ${server} after revoke"],
+  }
+
+  exec { "update crl.pem on ${server} after revoke":
+    command  => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ${etc_directory}/openvpn/${server}/crl.pem -config ${etc_directory}/openvpn/${server}/easy-rsa/openssl.cnf",
+    cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
+    provider => 'shell',
+    refreshonly => true,
   }
 }

--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -60,7 +60,7 @@ define openvpn::revoke (
   $etc_directory = $::openvpn::params::etc_directory
 
   exec { "revoke certificate for ${name} in context of ${server}":
-    command  => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
+    command  => ". ./vars && ./easyrsa --batch revoke ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
     cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
     creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
     provider => 'shell',


### PR DESCRIPTION
The `revoke-full` script is no longer part of easyrsa.

This code has been tested in our environment.
